### PR TITLE
Change parent of model to ragdoll

### DIFF
--- a/scripts/vscripts/prefabs/npc/easy_bonemerge.lua
+++ b/scripts/vscripts/prefabs/npc/easy_bonemerge.lua
@@ -15,12 +15,8 @@ function NpcRagdollCreated(_, data)
         for _, child in ipairs(npc:GetChildren()) do
             if vlua.find(child:GetName(), "bonemerge", 1) then
                 --print("Found bonemerge", child:GetModelName())
-                -- Spawning the new prop to merge with the new ragdoll
-                local prop = SpawnEntityFromTableSynchronous("prop_dynamic", {
-                    model = child:GetModelName(),
-                    solid = "0"
-                })
-                prop:SetParent(ragdoll, "!bonemerge")
+                -- Attaching the model to the new ragdoll
+                child:SetParent(ragdoll, "!bonemerge")
                 ragdoll:SetRenderAlpha(0)
             end
         end


### PR DESCRIPTION
Instead of creating a new instance when the ragdoll spawns we can simply change the parent of the existing instance. This should improve performance. This also fixes the model getting randomized on death when using `citizens_male.vmdl` or `citizens_female.vmdl`.